### PR TITLE
Add support for RefreshIndicator

### DIFF
--- a/lib/src/lazy_load_scrollview.dart
+++ b/lib/src/lazy_load_scrollview.dart
@@ -11,7 +11,7 @@ typedef void EndOfPageListenerCallback();
 /// reaches the bottom of the list
 class LazyLoadScrollView extends StatefulWidget {
   /// The [ScrollView] that this widget watches for changes on
-  final ScrollView child;
+  final Widget child;
 
   /// Called when the [child] reaches the end of the list
   final EndOfPageListenerCallback onEndOfPage;


### PR DESCRIPTION
This change makes the use of RefreshIndicator with LazyLoadScrollView possible.

E.g.

```
LazyLoadScrollView(
      onEndOfPage: () {
        //...
      },
      child: RefreshIndicator(
        onRefresh: () async {
          print('On refresh');
          return;
        },
        child: ListView.builder(
            //...
            ),
      ),
    );
```

