### PR TITLE
Updated example and v2 of lazy_load_scrollview

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,21 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    # - public_member_api_docs
+    - require_trailing_commas
+    - parameter_assignments
+    - only_throw_errors
+    - always_use_package_imports
+    - avoid_dynamic_calls
+    - prefer_void_to_null
+    - always_declare_return_types
+    - avoid_classes_with_only_static_members
+    - unnecessary_lambdas
+    - unnecessary_const
+    - avoid_void_async

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,74 +1,84 @@
 import 'package:flutter/material.dart';
 import 'package:lazy_load_scrollview/lazy_load_scrollview.dart';
 
-void main() => runApp(new MyApp());
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return const MaterialApp(
       title: 'Lazy Load Demo',
-      home: new MyHomePage(title: 'Lazy Load Demo'),
+      home: MyHomePage(title: 'Lazy Load Demo'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
 
   final String title;
 
   @override
-  _MyHomePageState createState() => new _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  final scrollController = ScrollController();
+
   List<int> verticalData = [];
   List<int> horizontalData = [];
 
   final int increment = 10;
 
-  bool isLoadingVertical = false;
-  bool isLoadingHorizontal = false;
-
   @override
   void initState() {
     _loadMoreVertical();
-    _loadMoreHorizontal();
+    _loadMoreHorizontalAfter();
     super.initState();
   }
 
-  Future _loadMoreVertical() async {
-    setState(() {
-      isLoadingVertical = true;
-    });
-
-    // Add in an artificial delay
-    await new Future.delayed(const Duration(seconds: 2));
-
-    verticalData.addAll(
-        List.generate(increment, (index) => verticalData.length + index));
-
-    setState(() {
-      isLoadingVertical = false;
-    });
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
   }
 
-  Future _loadMoreHorizontal() async {
-    setState(() {
-      isLoadingHorizontal = true;
-    });
-
+  Future _loadMoreVertical() async {
     // Add in an artificial delay
-    await new Future.delayed(const Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    verticalData.addAll(
+      List.generate(increment, (index) => verticalData.length + index),
+    );
+    setState(() {});
+  }
+
+  Future _loadMoreHorizontalBefore() async {
+    // Add in an artificial delay
+    await Future<void>.delayed(const Duration(seconds: 2));
+
+    final firstIndex = horizontalData.first - 1;
+
+    final previousToAdd = List.generate(
+      increment,
+      (index) => firstIndex - index,
+    );
+
+    horizontalData = [...previousToAdd.reversed, ...horizontalData];
+
+    setState(() {});
+  }
+
+  Future _loadMoreHorizontalAfter() async {
+    // Add in an artificial delay
+    await Future<void>.delayed(const Duration(seconds: 2));
 
     horizontalData.addAll(
-        List.generate(increment, (index) => horizontalData.length + index));
-
-    setState(() {
-      isLoadingHorizontal = false;
-    });
+      List.generate(increment, (index) => horizontalData.length + index),
+    );
+    setState(() {});
   }
 
   @override
@@ -78,49 +88,87 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: LazyLoadScrollView(
-        isLoading: isLoadingVertical,
-        onEndOfPage: () => _loadMoreVertical(),
-        child: Scrollbar(
-          child: ListView(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Text(
-                  'Nested horizontal ListView',
-                  textAlign: TextAlign.center,
+        onLoadAfter: _loadMoreVertical,
+        controller: scrollController,
+        builder: (context, isLoadingAfter, _) {
+          // FIXME: I don't think this is true
+          // Scrollbar eats notifications ?? so we'll just use a scroll controller
+          return Scrollbar(
+            child: ListView(
+              controller: scrollController,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: Text(
+                    'Nested horizontal ListView',
+                    textAlign: TextAlign.center,
+                  ),
                 ),
-              ),
-              Container(
-                  height: 180,
+                SizedBox(
+                  height: 300.0,
                   child: LazyLoadScrollView(
-                      isLoading: isLoadingHorizontal,
-                      scrollDirection: Axis.horizontal,
-                      onEndOfPage: () => _loadMoreHorizontal(),
-                      child: Scrollbar(
-                          child: ListView.builder(
-                              itemCount: horizontalData.length,
-                              scrollDirection: Axis.horizontal,
-                              itemBuilder: (context, position) {
-                                return DemoItem(position);
-                              })))),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Text(
-                  'Vertical ListView',
-                  textAlign: TextAlign.center,
+                    onLoadAfter: _loadMoreHorizontalAfter,
+                    onLoadBefore: _loadMoreHorizontalBefore,
+                    builder: (
+                      BuildContext context,
+                      bool isLoadingAfter,
+                      bool isLoadingBefore,
+                    ) {
+                      return CustomScrollView(
+                        scrollDirection: Axis.horizontal,
+                        slivers: [
+                          if (isLoadingBefore)
+                            const SliverToBoxAdapter(
+                              child: Center(child: CircularProgressIndicator()),
+                            ),
+                          SliverList(
+                            delegate: SliverChildBuilderDelegate(
+                              (context, index) {
+                                final position = horizontalData[index];
+
+                                return DemoItem(
+                                  position,
+                                  key: ValueKey(position),
+                                );
+                              },
+                              childCount: horizontalData.length,
+                              findChildIndexCallback: (key) {
+                                final valueKey = (key as ValueKey<int>).value;
+
+                                return horizontalData.indexOf(valueKey);
+                              },
+                            ),
+                          ),
+                          if (isLoadingAfter)
+                            const SliverToBoxAdapter(
+                              child: Center(child: CircularProgressIndicator()),
+                            ),
+                        ],
+                      );
+                    },
+                  ),
                 ),
-              ),
-              ListView.builder(
-                shrinkWrap: true,
-                physics: NeverScrollableScrollPhysics(),
-                itemCount: verticalData.length,
-                itemBuilder: (context, position) {
-                  return DemoItem(position);
-                },
-              ),
-            ],
-          ),
-        ),
+                const Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: Text(
+                    'Vertical ListView',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: verticalData.length,
+                  itemBuilder: (context, position) {
+                    return DemoItem(position);
+                  },
+                ),
+                if (isLoadingAfter)
+                  const Center(child: CircularProgressIndicator()),
+              ],
+            ),
+          );
+        },
       ),
     );
   }
@@ -152,12 +200,13 @@ class DemoItem extends StatelessWidget {
                     height: 40.0,
                     width: 40.0,
                   ),
-                  SizedBox(width: 8.0),
-                  Text("Item $position"),
+                  const SizedBox(width: 8.0),
+                  Text("Item ${position.toString()}"),
                 ],
               ),
-              Text(
-                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sed vulputate orci. Proin id scelerisque velit. Fusce at ligula ligula. Donec fringilla sapien odio, et faucibus tortor finibus sed. Aenean rutrum ipsum in sagittis auctor. Pellentesque mattis luctus consequat. Sed eget sapien ut nibh rhoncus cursus. Donec eget nisl aliquam, ornare sapien sit amet, lacinia quam."),
+              const Text(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sed vulputate orci. Proin id scelerisque velit. Fusce at ligula ligula. Donec fringilla sapien odio, et faucibus tortor finibus sed. Aenean rutrum ipsum in sagittis auctor. Pellentesque mattis luctus consequat. Sed eget sapien ut nibh rhoncus cursus. Donec eget nisl aliquam, ornare sapien sit amet, lacinia quam.",
+              ),
             ],
           ),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -55,6 +55,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -66,7 +73,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -80,7 +94,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -99,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,5 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.0
+  
 flutter:
   uses-material-design: true

--- a/lib/src/lazy_load_scrollview.dart
+++ b/lib/src/lazy_load_scrollview.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 // TODO: How does this know it's reached the end of the list?
-/// A function signature for a builder that recieves loading widgets to be
+/// A function signature for a builder that receives loading widgets to be
 /// inserted into a ListView when further data is being fetched.
 typedef LazyLoadBuilder = Widget Function(
   BuildContext context,

--- a/lib/src/lazy_load_scrollview.dart
+++ b/lib/src/lazy_load_scrollview.dart
@@ -1,89 +1,296 @@
-library lazy_load_scrollview;
+import 'dart:async';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
-enum LoadingStatus { LOADING, STABLE }
+// TODO: How does this know it's reached the end of the list?
+/// A function signature for a builder that recieves loading widgets to be
+/// inserted into a ListView when further data is being fetched.
+typedef LazyLoadBuilder = Widget Function(
+  BuildContext context,
+  bool isLoadingAfter,
+  bool isLoadingBefore,
+);
 
-/// Signature for EndOfPageListeners
-typedef void EndOfPageListenerCallback();
-
-/// A widget that wraps a [Widget] and will trigger [onEndOfPage] when it
-/// reaches the bottom of the list
 class LazyLoadScrollView extends StatefulWidget {
-  /// The [Widget] that this widget watches for changes on
-  final Widget child;
+  /// A lazy builder that will be used to create the list widget. It also
+  /// carries the context of the child and a loading widget to be inserted into
+  /// the ListViews.
+  ///
+  /// Note, the direct child of this widget should be the [ListView]. If it is
+  /// not and the [ListView] is further down the tree then it's likely that this
+  /// will Builder will fail to recognize scroll events unless [ignoreDepth] is
+  /// set to true.
+  final LazyLoadBuilder builder;
 
-  /// Called when the [child] reaches the end of the list
-  final EndOfPageListenerCallback onEndOfPage;
+  /// The offset from the end at which the [onLoadBefore] or [onLoadAfter] will
+  /// be called.
+  final double scrollOffset;
 
-  /// The offset to take into account when triggering [onEndOfPage] in pixels
-  final int scrollOffset;
+  /// Called when more content is needed at the end of the main scroll axis
+  final AsyncCallback? onLoadAfter;
 
-  /// Used to determine if loading of new data has finished. You should use set this if you aren't using a FutureBuilder or StreamBuilder
-  final bool isLoading;
+  /// Called when more content is needed at the start of the main scroll axis
+  final AsyncCallback? onLoadBefore;
 
-  /// Prevented update nested listview with other axis direction
-  final Axis scrollDirection;
+  final Duration timeout;
+
+  /// The duration until either [onLoadBefore] or [onLoadAfter] is called.
+  /// The debounce strategy is eager. That means the callback will be called
+  /// first then further calls will be ignored until the timeout expires.
+  final Duration debounceDuration;
+
+  /// Whether to ignore the depth of the [ListView] when calling [onLoadBefore]
+  /// or [onLoadAfter]. This value is ignored if [controller] is set.
+  final bool ignoreDepth;
+
+  /// A check that specifies whether a [ScrollNotification] should be
+  /// handled by this widget.
+  ///
+  /// By default, checks whether `notification.depth == 0`. That means if the
+  /// scrollbar is wrapped around multiple [ScrollView]s, it only responds to the
+  /// nearest scrollView and shows the corresponding scrollbar thumb.
+  ///
+  /// Copied from [RawScrollBar]
+  ///
+  /// This value is ignored [controller] is non null or [ignoreDepth] is true.
+  final ScrollNotificationPredicate? notificationPredicate;
+
+  /// This widget can either listen to notifications through a
+  /// [NotificationListener] or it can listen to a [ScrollListener] and handle
+  /// the scroll events directly.
+  final ScrollController? controller;
+
+  const LazyLoadScrollView({
+    Key? key,
+    required this.builder,
+    this.onLoadAfter,
+    this.onLoadBefore,
+    this.scrollOffset = 100.0,
+    this.debounceDuration = const Duration(milliseconds: 500),
+    this.timeout = const Duration(seconds: 10),
+    this.ignoreDepth = false,
+    this.notificationPredicate = defaultScrollNotificationPredicate,
+    this.controller,
+  }) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => LazyLoadScrollViewState();
-
-  LazyLoadScrollView({
-    Key? key,
-    required this.child,
-    required this.onEndOfPage,
-    this.scrollDirection = Axis.vertical,
-    this.isLoading = false,
-    this.scrollOffset = 100,
-  }) : super(key: key);
+  State<LazyLoadScrollView> createState() => _LazyListBuilderState();
 }
 
-class LazyLoadScrollViewState extends State<LazyLoadScrollView> {
-  LoadingStatus loadMoreStatus = LoadingStatus.STABLE;
+class _LazyListBuilderState extends State<LazyLoadScrollView> {
+  AxisDirection? scrollDirection;
+
+  bool isLoadingBefore = false;
+
+  bool isLoadingAfter = false;
+
+  Timer? timer;
+
+  Future<void> loadBefore() async {
+    if (widget.onLoadBefore == null || isLoadingBefore) return;
+
+    // If we have a timer going, just return early.
+    if (timer?.isActive ?? false) {
+      return;
+    } else {
+      setState(() => isLoadingBefore = true);
+
+      if (mounted) {
+        await widget.onLoadBefore?.call().timeout(widget.timeout);
+        setState(() => isLoadingBefore = false);
+      }
+
+      timer = Timer(widget.debounceDuration, () {});
+    }
+  }
+
+  Future<void> loadAfter() async {
+    if (widget.onLoadAfter == null || isLoadingAfter) return;
+
+    if (timer?.isActive ?? false) {
+      return;
+    } else {
+      setState(() => isLoadingAfter = true);
+
+      if (mounted) {
+        // TODO: Will these need completers to correctly handle errors?
+        await widget.onLoadAfter?.call().timeout(widget.timeout);
+        setState(() => isLoadingAfter = false);
+      }
+
+      timer = Timer(widget.debounceDuration, () {});
+    }
+  }
 
   @override
-  void didUpdateWidget(LazyLoadScrollView oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!widget.isLoading) {
-      loadMoreStatus = LoadingStatus.STABLE;
+  void initState() {
+    widget.controller?.addListener(_scrollListener);
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(covariant LazyLoadScrollView oldWidget) {
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.removeListener(_scrollListener);
+      widget.controller?.addListener(_scrollListener);
     }
+
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_scrollListener);
+    timer?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    if (widget.controller != null) {
+      return widget.builder(context, isLoadingAfter, isLoadingBefore);
+    }
+
     return NotificationListener<ScrollNotification>(
-      child: widget.child,
-      onNotification: (notification) => _onNotification(notification, context),
+      child: widget.builder(context, isLoadingAfter, isLoadingBefore),
+      onNotification: (notification) {
+        if (widget.ignoreDepth ||
+            (widget.notificationPredicate?.call(notification) ?? false)) {
+          final axis = notification.metrics.axis;
+          final axisDirection = notification.metrics.axisDirection;
+          final extentBefore = notification.metrics.extentBefore;
+          final extentAfter = notification.metrics.extentAfter;
+
+          if (notification is ScrollUpdateNotification) {
+            final deltaOffset = notification.dragDetails?.delta;
+
+            if (deltaOffset != null) {
+              if (deltaOffset.dx != 0 && axis == Axis.horizontal) {
+                if (deltaOffset.dx < 0) {
+                  scrollDirection = AxisDirection.right;
+                } else {
+                  scrollDirection = AxisDirection.left;
+                }
+              }
+
+              if (deltaOffset.dy != 0 && axis == Axis.vertical) {
+                if (deltaOffset.dy < 0) {
+                  scrollDirection = AxisDirection.down;
+                } else {
+                  scrollDirection = AxisDirection.up;
+                }
+              }
+            }
+
+            _handleScrollUpdate(
+              axis: axis,
+              axisDirection: axisDirection,
+              extentAfter: extentAfter,
+              extentBefore: extentBefore,
+            );
+          }
+
+          if (notification is OverscrollNotification) {
+            _handleOverScroll(
+              axisDirection: axisDirection,
+              extentAfter: extentAfter,
+              extentBefore: extentBefore,
+            );
+          }
+        }
+
+        return false;
+      },
     );
   }
 
-  bool _onNotification(ScrollNotification notification, BuildContext context) {
-    if (widget.scrollDirection == notification.metrics.axis) {
-      if (notification is ScrollUpdateNotification) {
-        if (notification.metrics.maxScrollExtent >
-                notification.metrics.pixels &&
-            notification.metrics.maxScrollExtent -
-                    notification.metrics.pixels <=
-                widget.scrollOffset) {
-          _loadMore();
-        }
-        return true;
-      }
+  void _scrollListener() {
+    // Assume non-null otherwise it wouldn't have gotten called.
+    final controller = widget.controller!;
+    final axis = controller.position.axis;
+    final axisDirection = controller.position.axisDirection;
+    final extentBefore = controller.position.extentBefore;
+    final extentAfter = controller.position.extentAfter;
+    final userScrollDirection = controller.position.userScrollDirection;
 
-      if (notification is OverscrollNotification) {
-        if (notification.overscroll > 0) {
-          _loadMore();
+    switch (userScrollDirection) {
+      case ScrollDirection.idle:
+        return;
+      case ScrollDirection.forward:
+        switch (axis) {
+          case Axis.horizontal:
+            scrollDirection = AxisDirection.right;
+            break;
+          case Axis.vertical:
+            scrollDirection = AxisDirection.up;
+            break;
         }
-        return true;
-      }
+        break;
+      case ScrollDirection.reverse:
+        switch (axis) {
+          case Axis.horizontal:
+            scrollDirection = AxisDirection.left;
+            break;
+          case Axis.vertical:
+            scrollDirection = AxisDirection.down;
+            break;
+        }
+        break;
     }
-    return false;
+
+    _handleScrollUpdate(
+      axis: axis,
+      axisDirection: axisDirection,
+      extentAfter: extentAfter,
+      extentBefore: extentBefore,
+    );
+
+    if (controller.position.outOfRange) {
+      _handleOverScroll(
+        axisDirection: axisDirection,
+        extentAfter: extentAfter,
+        extentBefore: extentBefore,
+      );
+    }
   }
 
-  void _loadMore() {
-    if (loadMoreStatus == LoadingStatus.STABLE) {
-      loadMoreStatus = LoadingStatus.LOADING;
-      widget.onEndOfPage();
+  void _handleScrollUpdate({
+    required Axis axis,
+    required AxisDirection axisDirection,
+    required double extentAfter,
+    required double extentBefore,
+  }) {
+    // scrollDirection comes from widget state
+    if (axisDirection == scrollDirection &&
+        extentAfter <= widget.scrollOffset) {
+      loadAfter();
+    }
+
+    if (flipAxisDirection(axisDirection) == scrollDirection &&
+        extentBefore <= widget.scrollOffset) {
+      loadBefore();
+    }
+  }
+
+  void _handleOverScroll({
+    required AxisDirection axisDirection,
+    required double extentAfter,
+    required double extentBefore,
+  }) {
+    final _scrollDirection = scrollDirection;
+    assert(_scrollDirection != null);
+
+    if (_scrollDirection != null) {
+      if (axisDirection == _scrollDirection && extentAfter == 0) {
+        loadAfter();
+      }
+
+      if (flipAxisDirection(axisDirection) == _scrollDirection &&
+          extentBefore == 0) {
+        loadBefore();
+      }
     }
   }
 }

--- a/lib/src/lazy_load_scrollview.dart
+++ b/lib/src/lazy_load_scrollview.dart
@@ -18,10 +18,11 @@ class LazyLoadScrollView extends StatefulWidget {
   /// carries the context of the child and a loading widget to be inserted into
   /// the ListViews.
   ///
-  /// Note, the direct child of this widget should be the [ListView]. If it is
-  /// not and the [ListView] is further down the tree then it's likely that this
-  /// will Builder will fail to recognize scroll events unless [ignoreDepth] is
-  /// set to true.
+  /// The [Scrollable] should be a direct child of this builder for us to listen
+  /// to bubbling events. If it is not the direct child, you must further specify
+  /// a predicate in order to find it in the descendents or, if there are no other
+  /// scrollables, set [ignoreDepth] to true. If you'd like to avoid a
+  /// predicate, you may also provide an optional [ScrollController].
   final LazyLoadBuilder builder;
 
   /// The offset from the end at which the [onLoadBefore] or [onLoadAfter] will
@@ -98,8 +99,11 @@ class _LazyListBuilderState extends State<LazyLoadScrollView> {
       setState(() => isLoadingBefore = true);
 
       if (mounted) {
-        await widget.onLoadBefore?.call().timeout(widget.timeout);
-        setState(() => isLoadingBefore = false);
+        await widget.onLoadBefore?.call().timeout(widget.timeout).whenComplete(
+          () {
+            setState(() => isLoadingBefore = false);
+          },
+        );
       }
 
       timer = Timer(widget.debounceDuration, () {});
@@ -115,9 +119,11 @@ class _LazyListBuilderState extends State<LazyLoadScrollView> {
       setState(() => isLoadingAfter = true);
 
       if (mounted) {
-        // TODO: Will these need completers to correctly handle errors?
-        await widget.onLoadAfter?.call().timeout(widget.timeout);
-        setState(() => isLoadingAfter = false);
+        await widget.onLoadAfter?.call().timeout(widget.timeout).whenComplete(
+          () {
+            setState(() => isLoadingAfter = false);
+          },
+        );
       }
 
       timer = Timer(widget.debounceDuration, () {});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -55,11 +55,25 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -73,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.0


### PR DESCRIPTION
Hello ! I didn't know of the existence of this package and ended up creating listview notifier similar to this but slightly different. In any case, I'd like to offer it up as a PR. To improve I took both my ideas and your ideas and kind of squashed them together as well as implemented a few things from the issues here.

Here are a few things the new:

*  lazyloadscrollview takes an optional ScrollController now that will work in place of bubbling notifier events (this is useful to avoid predicates)
* Added notificationPredicate #15 
* Added an example on how to add animation when reached the end #2 
* lazyloadscrollview can now work in both directions of a listview
* Added debounce timer that will prevent the callback from firiing a bunch of times

Breaking change:

* the lazyloadscrollview takes a builder instead of a child. This builder passes through isLoadingBefore and isLoadingAfter that tell the user when the respective async op is running.
* Renamed onEndOfPage to to onLoadAfter

I'd love to get your opinion on this big change. Leaving it as a draft for now