### PR TITLE
[FIX]  #17 - Fast scroll not calls onEndPage on iOS

### DIFF
--- a/lib/src/lazy_load_scrollview.dart
+++ b/lib/src/lazy_load_scrollview.dart
@@ -58,24 +58,10 @@ class LazyLoadScrollViewState extends State<LazyLoadScrollView> {
   }
 
   bool _onNotification(ScrollNotification notification, BuildContext context) {
-    if (widget.scrollDirection == notification.metrics.axis) {
-      if (notification is ScrollUpdateNotification) {
-        if (notification.metrics.maxScrollExtent >
-                notification.metrics.pixels &&
-            notification.metrics.maxScrollExtent -
-                    notification.metrics.pixels <=
-                widget.scrollOffset) {
-          _loadMore();
-        }
-        return true;
-      }
-
-      if (notification is OverscrollNotification) {
-        if (notification.overscroll > 0) {
-          _loadMore();
-        }
-        return true;
-      }
+    if (widget.scrollDirection == notification.metrics.axis &&
+        notification is ScrollEndNotification) {
+      _loadMore();
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
 - Fix the issue  #17
 -The fix was made changing the Notification type to listen for